### PR TITLE
[BUGFIX] remove html_entity_decode

### DIFF
--- a/Classes/Utility/RenderUtility.php
+++ b/Classes/Utility/RenderUtility.php
@@ -82,7 +82,7 @@ class RenderUtility
             }
         }
 
-        return str_replace('<?xml encoding="UTF-8">', '', html_entity_decode($doc->saveHTML()));
+        return str_replace('<?xml encoding="UTF-8">', '', $doc->saveHTML());
     }
 
     /**
@@ -150,7 +150,7 @@ class RenderUtility
             }
         }
 
-        return str_replace('<?xml encoding="UTF-8">', '', html_entity_decode($doc->saveHTML()));
+        return str_replace('<?xml encoding="UTF-8">', '', $doc->saveHTML());
     }
 
     /**


### PR DESCRIPTION
the new returned HTML-Content should not be decoded, as it also decodes escaped html character which are intended to not be rendered. This is a huge security issue.