### PR TITLE
Danish lng 1.4.x

### DIFF
--- a/Classes/Updates/StaticDataUpdateWizard.php
+++ b/Classes/Updates/StaticDataUpdateWizard.php
@@ -128,7 +128,8 @@ class StaticDataUpdateWizard implements UpgradeWizardInterface
 
         $allowedUnknownLocales = [
             "de" ,
-            "en"
+            "en",
+            "da"
         ];
         foreach ($allowedUnknownLocales as $allowedUnknownLocale) {
             if(strpos(strtolower($locale),$allowedUnknownLocale) !== false){

--- a/Resources/Private/Language/da.locallang.xlf
+++ b/Resources/Private/Language/da.locallang.xlf
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<xliff version="1.0">
+	<file source-language="en" target-language="da" datatype="plaintext"  date="2024-27-08T16:02:12Z" product-name="cf_cookiemanager">
+        <header/>
+        <body>
+            <trans-unit id="frontend_cookie_name" xml:space="preserve">
+                <source>Name</source>
+                <target>Navn</target>
+            </trans-unit>
+            <trans-unit id="frontend_cookie_provider" xml:space="preserve">
+                <source>Provider</source>
+                <target>Udbyder</target>
+            </trans-unit>
+            <trans-unit id="frontend_cookie_expiry" xml:space="preserve">
+                <source>Expiry</source>
+                <target>Udløbsdato</target>
+            </trans-unit>
+            <trans-unit id="frontend_cookie_domain" xml:space="preserve">
+                <source>Domain</source>
+                <target>Domæne</target>
+            </trans-unit>
+            <trans-unit id="frontend_cookie_path" xml:space="preserve">
+                <source>Path</source>
+                <target>Sti</target>
+            </trans-unit>
+            <trans-unit id="frontend_cookie_secure" xml:space="preserve">
+                <source>Only Https</source>
+                <target>Kun HTTPS</target>
+            </trans-unit>
+            <trans-unit id="frontend_cookie_description" xml:space="preserve">
+                <source>Description</source>
+                <target>Beskrivelse</target>
+            </trans-unit>
+            <trans-unit id="scriptblocked" xml:space="preserve">
+                <source>Service blocked by Script-blocker</source>
+                <target>Denne service blokeres af Script-blocker</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Resources/Private/Language/da.locallang_cookiesettings.xlf
+++ b/Resources/Private/Language/da.locallang_cookiesettings.xlf
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<xliff version="1.0">
+	<file source-language="en" target-language="da" datatype="plaintext" original="EXT:cf_cookiemanager/Resources/Private/Language/locallang_cookiesettings.xlf" date="2024-27-08T15:58:41Z" product-name="cf_cookiemanager">
+		<header/>
+		<body>
+			<trans-unit id="mlang_labels_tabdescr" resname="mlang_labels_tabdescr">
+				<source></source>
+				<target></target>
+			</trans-unit>
+			<trans-unit id="mlang_tabs_tab" resname="mlang_tabs_tab">
+				<source>Cookie Settings</source>
+				<target>Cookieindstillinger</target>
+			</trans-unit>
+		</body>
+	</file>
+</xliff>


### PR DESCRIPTION
Danish language files for the Typo3 v11 compatible branch.

Best regards!