### PR TITLE
[BUGFIX] add missing label for toggle

### DIFF
--- a/Resources/Public/JavaScript/thirdparty/consent.js
+++ b/Resources/Public/JavaScript/thirdparty/consent.js
@@ -718,6 +718,10 @@
                         block_switch2.checked = true;
                     }
 
+                    // Add label for toggle
+                    var block_switchlabel = category.querySelector(".t-lb");
+                    block_switchlabel.innerText = categories[ii]["title"];
+
                     //category.setAttribute('aria-hidden', 'true');
 
                     /**


### PR DESCRIPTION
Actually a changed HTML-Template with aria-labelledby referencing the button might be a better solution. However that would be a breaking change for users with customized templates.

Fixes #56 