### PR TITLE
[BUGFIX] Check for external scripts as an ObjectStorage()

### DIFF
--- a/Classes/Domain/Repository/CookieFrontendRepository.php
+++ b/Classes/Domain/Repository/CookieFrontendRepository.php
@@ -562,7 +562,7 @@ class CookieFrontendRepository extends \TYPO3\CMS\Extbase\Persistence\Repository
                 foreach ($services as $service) {
                     $allExternalScripts = $service->getExternalScripts();
                     $allVariables = $service->getVariablePriovider();
-                    if (!empty($allExternalScripts)) {
+                    if ($allExternalScripts->count()) {
                         foreach ($allExternalScripts as $externalScript) {
                             $string = $this->variablesRepository->replaceVariable($externalScript->getLink(), $allVariables);
                             GeneralUtility::makeInstance(AssetCollector::class)->addJavaScript(


### PR DESCRIPTION
Prevent creating mistakenly inline JavaScript code with OptInCode that doubles OptInCode execution.