### PR TITLE
[BUGFIX] Fix typos and grammar in source language labels

### DIFF
--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -64,7 +64,7 @@
 				<source>Fallback Code</source>
 			</trans-unit>
 			<trans-unit id="tx_cfcookiemanager_domain_model_cookieservice.dsgvo_link" resname="tx_cfcookiemanager_domain_model_cookieservice.dsgvo_link">
-				<source>Dsgvo Link</source>
+				<source>DSGVO Link</source>
 			</trans-unit>
 			<trans-unit id="tx_cfcookiemanager_domain_model_cookieservice.iframe_embed_url" resname="tx_cfcookiemanager_domain_model_cookieservice.iframe_embed_url">
 				<source>Iframe Embed function or url</source>
@@ -471,7 +471,7 @@
 				<source>Default description text shown in service block in the settings modal</source>
 			</trans-unit>
 			<trans-unit id="tx_cfcookiemanager_domain_model_cookiefrontend.custombutton.description" resname="tx_cfcookiemanager_domain_model_cookiefrontend.custombutton.description">
-				<source>Enable to use a custom HTML button instead of the default "Manage cookie settings" trigger button. @deprecaed please us extbase templates in future. (see eg. https://github.com/eibiflo/cf_cookiemanager_uikit)</source>
+				<source>Enable to use a custom HTML button instead of the default "Manage cookie settings" trigger button. @deprecated please use extbase templates in future. (see eg. https://github.com/eibiflo/cf_cookiemanager_uikit)</source>
 			</trans-unit>
 			<trans-unit id="tx_cfcookiemanager_domain_model_cookiefrontend.custom_button_html.description" resname="tx_cfcookiemanager_domain_model_cookiefrontend.custom_button_html.description">
 				<source>Custom HTML markup for the consent trigger button. Only used when the custom button option is enabled.</source>

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -67,19 +67,19 @@
 				<source>DSGVO Link</source>
 			</trans-unit>
 			<trans-unit id="tx_cfcookiemanager_domain_model_cookieservice.iframe_embed_url" resname="tx_cfcookiemanager_domain_model_cookieservice.iframe_embed_url">
-				<source>Iframe Embed function or url</source>
+				<source>iFrame Embed function or url</source>
 			</trans-unit>
 			<trans-unit id="tx_cfcookiemanager_domain_model_cookieservice.iframe_thumbnail_url" resname="tx_cfcookiemanager_domain_model_cookieservice.iframe_thumbnail_url">
-				<source>Iframe Thumbnail function or url</source>
+				<source>iFrame Thumbnail function or url</source>
 			</trans-unit>
 			<trans-unit id="tx_cfcookiemanager_domain_model_cookieservice.iframe_notice" resname="tx_cfcookiemanager_domain_model_cookieservice.iframe_notice">
-				<source>Iframe Notice</source>
+				<source>iFrame Notice</source>
 			</trans-unit>
 			<trans-unit id="tx_cfcookiemanager_domain_model_cookieservice.iframe_load_btn" resname="tx_cfcookiemanager_domain_model_cookieservice.iframe_load_btn">
-				<source>Iframe Load this frame button</source>
+				<source>iFrame Load this frame button</source>
 			</trans-unit>
 			<trans-unit id="tx_cfcookiemanager_domain_model_cookieservice.iframe_load_all_btn" resname="tx_cfcookiemanager_domain_model_cookieservice.iframe_load_all_btn">
-				<source>Iframe Load all from same service button</source>
+				<source>iFrame Load all from same service button</source>
 			</trans-unit>
 			<trans-unit id="tx_cfcookiemanager_domain_model_cookieservice.category_suggestion" resname="tx_cfcookiemanager_domain_model_cookieservice.category_suggestion">
 				<source>Category Suggestion</source>
@@ -294,10 +294,10 @@
 
 			<!-- Cookie Categories: Field Descriptions -->
 			<trans-unit id="tx_cfcookiemanager_domain_model_cookiecartegories.title.description" resname="tx_cfcookiemanager_domain_model_cookiecartegories.title.description">
-				<source>Enter the category name displayed to visitors in the consent modal.</source>
+				<source>Enter the category name displayed to visitors in the Consent Modal.</source>
 			</trans-unit>
 			<trans-unit id="tx_cfcookiemanager_domain_model_cookiecartegories.description.description" resname="tx_cfcookiemanager_domain_model_cookiecartegories.description.description">
-				<source>Provide a short explanation of this category shown to visitors in the consent modal.</source>
+				<source>Provide a short explanation of this category shown to visitors in the Consent Modal.</source>
 			</trans-unit>
 			<trans-unit id="tx_cfcookiemanager_domain_model_cookiecartegories.identifier.description" resname="tx_cfcookiemanager_domain_model_cookiecartegories.identifier.description">
 				<source>Unique system identifier for this category, used by the JavaScript API.</source>
@@ -306,7 +306,7 @@
 				<source>Enable to mark all services in this category as required, preventing visitors from opting out.</source>
 			</trans-unit>
 			<trans-unit id="tx_cfcookiemanager_domain_model_cookiecartegories.cookie_services.description" resname="tx_cfcookiemanager_domain_model_cookiecartegories.cookie_services.description">
-				<source>Assign cookie services to this category. Services appear grouped under this category in the consent modal.</source>
+				<source>Assign cookie services to this category. Services appear grouped under this category in the Consent Modal.</source>
 			</trans-unit>
 			<trans-unit id="tx_cfcookiemanager_domain_model_cookiecartegories.exclude_from_update.description" resname="tx_cfcookiemanager_domain_model_cookiecartegories.exclude_from_update.description">
 				<source>Exclude this record from automatic API synchronization to prevent local customizations from being overwritten.</source>
@@ -314,13 +314,13 @@
 
 			<!-- Cookie Services: Field Descriptions -->
 			<trans-unit id="tx_cfcookiemanager_domain_model_cookieservice.name.description" resname="tx_cfcookiemanager_domain_model_cookieservice.name.description">
-				<source>Enter the service display name shown to visitors in the consent modal.</source>
+				<source>Enter the service display name shown to visitors in the Consent Modal.</source>
 			</trans-unit>
 			<trans-unit id="tx_cfcookiemanager_domain_model_cookieservice.identifier.description" resname="tx_cfcookiemanager_domain_model_cookieservice.identifier.description">
 				<source>Unique system identifier used by the JavaScript API, for iframe data-service attributes and for API identification (CookieDatabase).</source>
 			</trans-unit>
 			<trans-unit id="tx_cfcookiemanager_domain_model_cookieservice.description.description" resname="tx_cfcookiemanager_domain_model_cookieservice.description.description">
-				<source>Provide a short explanation of this service shown to visitors in the consent modal settings view.</source>
+				<source>Provide a short explanation of this service shown to visitors in the Consent Modal settings view.</source>
 			</trans-unit>
 			<trans-unit id="tx_cfcookiemanager_domain_model_cookieservice.is_required.description" resname="tx_cfcookiemanager_domain_model_cookieservice.is_required.description">
 				<source>Pre-check this service by default (opt-out). This can also be applied at the category level for all services in a required category.</source>
@@ -329,7 +329,7 @@
 				<source>Prevent visitors from toggling this service off. This can also be applied at the category level for all services in a required category.</source>
 			</trans-unit>
 			<trans-unit id="tx_cfcookiemanager_domain_model_cookieservice.provider.description" resname="tx_cfcookiemanager_domain_model_cookieservice.provider.description">
-				<source>Enter the provider or service URL(s) for this service, separated by commas. Used for Autoreplacing Iframe and Scripts via Middleware, to load compliant.</source>
+				<source>Enter the provider or service URL(s) for this service, separated by commas. Used for Autoreplacing iframe and Scripts via Middleware, to load compliant.</source>
 			</trans-unit>
 			<trans-unit id="tx_cfcookiemanager_domain_model_cookieservice.opt_in_code.description" resname="tx_cfcookiemanager_domain_model_cookieservice.opt_in_code.description">
 				<source>JavaScript code executed when the visitor accepts this service. Use [##variableName##] syntax for template variables. (Variable Provider)</source>
@@ -356,7 +356,7 @@
 				<source>Button label text for loading all blocked iframes from the same service on the current page.</source>
 			</trans-unit>
 			<trans-unit id="tx_cfcookiemanager_domain_model_cookieservice.category_suggestion.description" resname="tx_cfcookiemanager_domain_model_cookieservice.category_suggestion.description">
-				<source>Suggested category identifier from auto-configuration. Used internally for the category selection interface.</source>
+				<source>Suggested category identifier from autoconfiguration. Used internally for the category selection interface.</source>
 			</trans-unit>
 			<trans-unit id="tx_cfcookiemanager_domain_model_cookieservice.cookie.description" resname="tx_cfcookiemanager_domain_model_cookieservice.cookie.description">
 				<source>Assign cookies that belong to this service. These cookies are managed automatically based on consent status.</source>
@@ -388,7 +388,7 @@
 				<source>The URL path scope for this cookie, e.g. "/" for the entire site.</source>
 			</trans-unit>
 			<trans-unit id="tx_cfcookiemanager_domain_model_cookie.description.description" resname="tx_cfcookiemanager_domain_model_cookie.description.description">
-				<source>Provide a short explanation of what this cookie is used for, shown to visitors in the settings modal.</source>
+				<source>Provide a short explanation of what this cookie is used for, shown to visitors in the Settings Modal.</source>
 			</trans-unit>
 			<trans-unit id="tx_cfcookiemanager_domain_model_cookie.expiry.description" resname="tx_cfcookiemanager_domain_model_cookie.expiry.description">
 				<source>Cookie expiration time in days. Enter 0 for session cookies that expire when the browser is closed.</source>
@@ -414,28 +414,28 @@
 				<source>Enable or disable this frontend configuration. Only one configuration should be active per site.</source>
 			</trans-unit>
 			<trans-unit id="tx_cfcookiemanager_domain_model_cookiefrontend.title_consent_modal.description" resname="tx_cfcookiemanager_domain_model_cookiefrontend.title_consent_modal.description">
-				<source>Heading text displayed at the top of the consent modal popup.</source>
+				<source>Heading text displayed at the top of the Consent Modal popup.</source>
 			</trans-unit>
 			<trans-unit id="tx_cfcookiemanager_domain_model_cookiefrontend.description_consent_modal.description" resname="tx_cfcookiemanager_domain_model_cookiefrontend.description_consent_modal.description">
-				<source>Main descriptive text shown in the consent modal. Supports rich text formatting.</source>
+				<source>Main descriptive text shown in the Consent Modal. Supports rich text formatting.</source>
 			</trans-unit>
 			<trans-unit id="tx_cfcookiemanager_domain_model_cookiefrontend.revision_text.description" resname="tx_cfcookiemanager_domain_model_cookiefrontend.revision_text.description">
-				<source>Additional text displayed at the bottom of the consent modal, e.g. for revision or legal notices. (Only visible if the revision version changed)</source>
+				<source>Additional text displayed at the bottom of the Consent Modal, e.g. for revision or legal notices. (Only visible if the revision version changed)</source>
 			</trans-unit>
 			<trans-unit id="tx_cfcookiemanager_domain_model_cookiefrontend.primary_btn_text_consent_modal.description" resname="tx_cfcookiemanager_domain_model_cookiefrontend.primary_btn_text_consent_modal.description">
-				<source>Label text for the primary button in the consent modal, e.g. "Accept all".</source>
+				<source>Label text for the primary button in the Consent Modal, e.g. "Accept all".</source>
 			</trans-unit>
 			<trans-unit id="tx_cfcookiemanager_domain_model_cookiefrontend.primary_btn_role_consent_modal.description" resname="tx_cfcookiemanager_domain_model_cookiefrontend.primary_btn_role_consent_modal.description">
 				<source>Define the action triggered by the primary button: accept all, open preferences, or accept necessary only.</source>
 			</trans-unit>
 			<trans-unit id="tx_cfcookiemanager_domain_model_cookiefrontend.secondary_btn_text_consent_modal.description" resname="tx_cfcookiemanager_domain_model_cookiefrontend.secondary_btn_text_consent_modal.description">
-				<source>Label text for the secondary button in the consent modal, e.g. "Reject all".</source>
+				<source>Label text for the secondary button in the Consent Modal, e.g. "Reject all".</source>
 			</trans-unit>
 			<trans-unit id="tx_cfcookiemanager_domain_model_cookiefrontend.secondary_btn_role_consent_modal.description" resname="tx_cfcookiemanager_domain_model_cookiefrontend.secondary_btn_role_consent_modal.description">
 				<source>Define the action triggered by the secondary button: accept all, open preferences, or accept necessary only.</source>
 			</trans-unit>
 			<trans-unit id="tx_cfcookiemanager_domain_model_cookiefrontend.tertiary_btn_text_consent_modal.description" resname="tx_cfcookiemanager_domain_model_cookiefrontend.tertiary_btn_text_consent_modal.description">
-				<source>Label text for the tertiary button in the consent modal. Select "Hide Button" role to disable.</source>
+				<source>Label text for the tertiary button in the Consent Modal. Select "Hide Button" role to disable.</source>
 			</trans-unit>
 			<trans-unit id="tx_cfcookiemanager_domain_model_cookiefrontend.tertiary_btn_role_consent_modal.description" resname="tx_cfcookiemanager_domain_model_cookiefrontend.tertiary_btn_role_consent_modal.description">
 				<source>Define the action triggered by the tertiary button: accept all, open preferences, accept necessary only, or hide this button.</source>
@@ -444,70 +444,70 @@
 				<source>Heading text displayed at the top of the settings (preferences/settings) modal.</source>
 			</trans-unit>
 			<trans-unit id="tx_cfcookiemanager_domain_model_cookiefrontend.save_btn_settings.description" resname="tx_cfcookiemanager_domain_model_cookiefrontend.save_btn_settings.description">
-				<source>Label text for the save preferences button in the settings modal.</source>
+				<source>Label text for the save preferences button in the Settings Modal.</source>
 			</trans-unit>
 			<trans-unit id="tx_cfcookiemanager_domain_model_cookiefrontend.accept_all_btn_settings.description" resname="tx_cfcookiemanager_domain_model_cookiefrontend.accept_all_btn_settings.description">
-				<source>Label text for the accept all button in the settings modal.</source>
+				<source>Label text for the accept all button in the Settings Modal.</source>
 			</trans-unit>
 			<trans-unit id="tx_cfcookiemanager_domain_model_cookiefrontend.reject_all_btn_settings.description" resname="tx_cfcookiemanager_domain_model_cookiefrontend.reject_all_btn_settings.description">
-				<source>Label text for the reject all button in the settings modal.</source>
+				<source>Label text for the reject all button in the Settings Modal.</source>
 			</trans-unit>
 			<trans-unit id="tx_cfcookiemanager_domain_model_cookiefrontend.close_btn_settings.description" resname="tx_cfcookiemanager_domain_model_cookiefrontend.close_btn_settings.description">
-				<source>Label text for the close button in the settings modal.</source>
+				<source>Label text for the close button in the Settings Modal.</source>
 			</trans-unit>
 			<trans-unit id="tx_cfcookiemanager_domain_model_cookiefrontend.col1_header_settings.description" resname="tx_cfcookiemanager_domain_model_cookiefrontend.col1_header_settings.description">
-				<source>Header text for the first column in the cookie table within the settings modal.</source>
+				<source>Header text for the first column in the cookie table within the Settings Modal.</source>
 			</trans-unit>
 			<trans-unit id="tx_cfcookiemanager_domain_model_cookiefrontend.col2_header_settings.description" resname="tx_cfcookiemanager_domain_model_cookiefrontend.col2_header_settings.description">
-				<source>Header text for the second column in the cookie table within the settings modal.</source>
+				<source>Header text for the second column in the cookie table within the Settings Modal.</source>
 			</trans-unit>
 			<trans-unit id="tx_cfcookiemanager_domain_model_cookiefrontend.col3_header_settings.description" resname="tx_cfcookiemanager_domain_model_cookiefrontend.col3_header_settings.description">
-				<source>Header text for the third column in the cookie table within the settings modal.</source>
+				<source>Header text for the third column in the cookie table within the Settings Modal.</source>
 			</trans-unit>
 			<trans-unit id="tx_cfcookiemanager_domain_model_cookiefrontend.blocks_title.description" resname="tx_cfcookiemanager_domain_model_cookiefrontend.blocks_title.description">
-				<source>Default title text shown above each service block in the settings modal.</source>
+				<source>Default title text shown above each service block in the Settings Modal.</source>
 			</trans-unit>
 			<trans-unit id="tx_cfcookiemanager_domain_model_cookiefrontend.blocks_description.description" resname="tx_cfcookiemanager_domain_model_cookiefrontend.blocks_description.description">
-				<source>Default description text shown in service block in the settings modal</source>
+				<source>Default description text shown in service block in the Settings Modal</source>
 			</trans-unit>
 			<trans-unit id="tx_cfcookiemanager_domain_model_cookiefrontend.custombutton.description" resname="tx_cfcookiemanager_domain_model_cookiefrontend.custombutton.description">
-				<source>Enable to use a custom HTML button instead of the default "Manage cookie settings" trigger button. @deprecated please use extbase templates in future. (see eg. https://github.com/eibiflo/cf_cookiemanager_uikit)</source>
+				<source>Enable to use a custom HTML button instead of the default "Manage cookie settings" trigger button. @deprecated please use extbase templates in future. (see e.g. https://github.com/eibiflo/cf_cookiemanager_uikit)</source>
 			</trans-unit>
 			<trans-unit id="tx_cfcookiemanager_domain_model_cookiefrontend.custom_button_html.description" resname="tx_cfcookiemanager_domain_model_cookiefrontend.custom_button_html.description">
 				<source>Custom HTML markup for the consent trigger button. Only used when the custom button option is enabled.</source>
 			</trans-unit>
 			<trans-unit id="tx_cfcookiemanager_domain_model_cookiefrontend.in_line_execution.description" resname="tx_cfcookiemanager_domain_model_cookiefrontend.in_line_execution.description">
-				<source>Enable to render the cookie manager JavaScript inline instead of as an "external" javascript file.</source>
+				<source>Enable to render the cookie manager JavaScript inline instead of as an "external" JavaScript file.</source>
 			</trans-unit>
 			<trans-unit id="tx_cfcookiemanager_domain_model_cookiefrontend.layout_consent_modal.description" resname="tx_cfcookiemanager_domain_model_cookiefrontend.layout_consent_modal.description">
-				<source>Choose the visual layout of the consent modal: box (centered popup), cloud (floating), or bar (full-width strip).</source>
+				<source>Choose the visual layout of the Consent Modal: box (centered popup), cloud (floating), or bar (full-width strip).</source>
 			</trans-unit>
 			<trans-unit id="tx_cfcookiemanager_domain_model_cookiefrontend.layout_settings.description" resname="tx_cfcookiemanager_domain_model_cookiefrontend.layout_settings.description">
-				<source>Choose the visual layout of the settings modal: box (centered overlay) or bar (side panel).</source>
+				<source>Choose the visual layout of the Settings Modal: box (centered overlay) or bar (side panel).</source>
 			</trans-unit>
 			<trans-unit id="tx_cfcookiemanager_domain_model_cookiefrontend.position_consent_modal.description" resname="tx_cfcookiemanager_domain_model_cookiefrontend.position_consent_modal.description">
-				<source>Set the screen position of the consent modal. Only available for box and cloud layouts.</source>
+				<source>Set the screen position of the Consent Modal. Only available for box and cloud layouts.</source>
 			</trans-unit>
 			<trans-unit id="tx_cfcookiemanager_domain_model_cookiefrontend.position_settings.description" resname="tx_cfcookiemanager_domain_model_cookiefrontend.position_settings.description">
-				<source>Set the screen position of the settings modal. Only available when bar layout is selected.</source>
+				<source>Set the screen position of the Settings Modal. Only available when bar layout is selected.</source>
 			</trans-unit>
 			<trans-unit id="tx_cfcookiemanager_domain_model_cookiefrontend.transition_consent_modal.description" resname="tx_cfcookiemanager_domain_model_cookiefrontend.transition_consent_modal.description">
-				<source>Choose the animation transition effect for the consent modal appearance.</source>
+				<source>Choose the animation transition effect for the Consent Modal appearance.</source>
 			</trans-unit>
 			<trans-unit id="tx_cfcookiemanager_domain_model_cookiefrontend.transition_settings.description" resname="tx_cfcookiemanager_domain_model_cookiefrontend.transition_settings.description">
-				<source>Choose the animation transition effect for the settings modal appearance.</source>
+				<source>Choose the animation transition effect for the Settings Modal appearance.</source>
 			</trans-unit>
 			<trans-unit id="tx_cfcookiemanager_domain_model_cookiefrontend.impress_text.description" resname="tx_cfcookiemanager_domain_model_cookiefrontend.impress_text.description">
-				<source>Link label text for the imprint page shown in the consent modal footer.</source>
+				<source>Link label text for the imprint page shown in the Consent Modal footer.</source>
 			</trans-unit>
 			<trans-unit id="tx_cfcookiemanager_domain_model_cookiefrontend.impress_link.description" resname="tx_cfcookiemanager_domain_model_cookiefrontend.impress_link.description">
-				<source>Link to the imprint (Impressum) page, displayed in the consent modal footer.</source>
+				<source>Link to the imprint (Impressum) page, displayed in the Consent Modal footer.</source>
 			</trans-unit>
 			<trans-unit id="tx_cfcookiemanager_domain_model_cookiefrontend.data_policy_text.description" resname="tx_cfcookiemanager_domain_model_cookiefrontend.data_policy_text.description">
-				<source>Link label text for the data privacy policy page shown in the consent modal footer.</source>
+				<source>Link label text for the data privacy policy page shown in the Consent Modal footer.</source>
 			</trans-unit>
 			<trans-unit id="tx_cfcookiemanager_domain_model_cookiefrontend.data_policy_link.description" resname="tx_cfcookiemanager_domain_model_cookiefrontend.data_policy_link.description">
-				<source>Link to the data privacy policy page, displayed in the consent modal footer.</source>
+				<source>Link to the data privacy policy page, displayed in the Consent Modal footer.</source>
 			</trans-unit>
 			<trans-unit id="tx_cfcookiemanager_domain_model_cookiefrontend.exclude_from_update.description" resname="tx_cfcookiemanager_domain_model_cookiefrontend.exclude_from_update.description">
 				<source>Exclude this record from automatic API synchronization to prevent local customizations from being overwritten.</source>
@@ -540,7 +540,7 @@
 				<source>Global Settings</source>
 			</trans-unit>
 			<trans-unit id="tx_cfcookiemanager_domain_model_cookieservice.tab.iframeManager" resname="tx_cfcookiemanager_domain_model_cookieservice.tab.iframeManager">
-				<source>Iframe Manager</source>
+				<source>iFrame Manager</source>
 			</trans-unit>
 			<trans-unit id="tx_cfcookiemanager_domain_model_cookieservice.tab.scripts" resname="tx_cfcookiemanager_domain_model_cookieservice.tab.scripts">
 				<source>Scripts</source>

--- a/Resources/Private/Language/locallang_js.xlf
+++ b/Resources/Private/Language/locallang_js.xlf
@@ -38,7 +38,7 @@
 				<source>Start Offline-Installation</source>
 			</trans-unit>
 			<trans-unit id="js.install.error" resname="js.install.error">
-				<source>Installation error. Please open an issue on Github with your error log.</source>
+				<source>Installation error. Please open an issue on GitHub with your error log.</source>
 			</trans-unit>
 			<trans-unit id="js.install.uploadFailed" resname="js.install.uploadFailed">
 				<source>Dataset upload failed.</source>
@@ -167,7 +167,7 @@
 				<source>Buttons</source>
 			</trans-unit>
 			<trans-unit id="tour.frontend.s7.content" resname="tour.frontend.s7.content" xml:space="preserve">
-				<source>The user can click to accept or reject the cookies. &lt;br&gt; You can change the &lt;strong&gt;text&lt;/strong&gt; and the &lt;strong&gt;button rule&lt;/strong&gt;.&lt;br&gt; We have a look at the Settings modal later.</source>
+				<source>The user can click to accept or reject the cookies. &lt;br&gt; You can change the &lt;strong&gt;text&lt;/strong&gt; and the &lt;strong&gt;button rule&lt;/strong&gt;.&lt;br&gt; We have a look at the Settings Modal later.</source>
 			</trans-unit>
 			<trans-unit id="tour.frontend.s8.title" resname="tour.frontend.s8.title">
 				<source>Layout</source>
@@ -185,7 +185,7 @@
 				<source>Title</source>
 			</trans-unit>
 			<trans-unit id="tour.frontend.s10.content" resname="tour.frontend.s10.content">
-				<source>Title of the Settings modal.</source>
+				<source>Title of the Settings Modal.</source>
 			</trans-unit>
 			<trans-unit id="tour.frontend.s11.title" resname="tour.frontend.s11.title">
 				<source>Buttons</source>
@@ -215,7 +215,7 @@
 				<source>Customize</source>
 			</trans-unit>
 			<trans-unit id="tour.frontend.s15.content" resname="tour.frontend.s15.content">
-				<source>Here you can insert a Custom HTML button for the right side of the Website, or disable it, by enable the custom-button and leave the field empty.</source>
+				<source>Here you can insert a Custom HTML button for the right side of the website, or disable it, by enable the custom-button and leave the field empty.</source>
 			</trans-unit>
 			<trans-unit id="tour.frontend.s16.title" resname="tour.frontend.s16.title">
 				<source>Customize</source>
@@ -233,7 +233,7 @@
 				<source>Name</source>
 			</trans-unit>
 			<trans-unit id="tour.frontend.s18.content" resname="tour.frontend.s18.content">
-				<source>Currently only used in the Backend as display name.</source>
+				<source>Currently only used in the backend as display name.</source>
 			</trans-unit>
 			<trans-unit id="tour.frontend.s19.title" resname="tour.frontend.s19.title">
 				<source>Impress</source>
@@ -265,7 +265,7 @@
 				<source>Create new Service</source>
 			</trans-unit>
 			<trans-unit id="tour.service.s2.content" resname="tour.service.s2.content" xml:space="preserve">
-				<source>In the background an empty new service was created. &lt;br&gt;&lt;br&gt; We need to set some basic information. Such as the &lt;strong&gt;name&lt;/strong&gt;, the &lt;strong&gt;identifier&lt;/strong&gt; and the &lt;strong&gt;description&lt;/strong&gt;. &lt;br&gt;In this example we use &lt;strong&gt;OpenStreetmap&lt;/strong&gt; from the documentation example: &lt;a target="_blank" href="https://docs.typo3.org/p/codingfreaks/cf-cookiemanager/main/en-us/Developer/CustomServices/Index.html#leaflet-openstreetmap"&gt;CLICK HERE -&gt;&lt;/a&gt;. &lt;br&gt; Type a name like "My OpenStreetmap Service" and press next.</source>
+				<source>In the background an empty new service was created. &lt;br&gt;&lt;br&gt; We need to set some basic information. Such as the &lt;strong&gt;name&lt;/strong&gt;, the &lt;strong&gt;identifier&lt;/strong&gt; and the &lt;strong&gt;description&lt;/strong&gt;. &lt;br&gt;In this example we use &lt;strong&gt;OpenStreetMap&lt;/strong&gt; from the documentation example: &lt;a target="_blank" href="https://docs.typo3.org/p/codingfreaks/cf-cookiemanager/main/en-us/Developer/CustomServices/Index.html#leaflet-openstreetmap"&gt;CLICK HERE -&gt;&lt;/a&gt;. &lt;br&gt; Type a name like "My OpenStreetMap Service" and press next.</source>
 			</trans-unit>
 			<trans-unit id="tour.service.s3.title" resname="tour.service.s3.title">
 				<source>Service identifier</source>
@@ -295,31 +295,31 @@
 				<source>Description</source>
 			</trans-unit>
 			<trans-unit id="tour.service.s7.content" resname="tour.service.s7.content">
-				<source>Add a description for the Frontend-Settings modal.</source>
+				<source>Add a description for the Frontend-Settings Modal.</source>
 			</trans-unit>
 			<trans-unit id="tour.service.s8.title" resname="tour.service.s8.title">
 				<source>Cookies</source>
 			</trans-unit>
 			<trans-unit id="tour.service.s8.content" resname="tour.service.s8.content" xml:space="preserve">
-				<source>Here you can add Cookies that are set by the service.&lt;br&gt; This is used for the cookie list in the frontend, and the Javascript-Cookie handling with autoclear. &lt;br&gt;For more information use the Cookie Tour. Press Next.</source>
+				<source>Here you can add Cookies that are set by the service.&lt;br&gt; This is used for the cookie list in the frontend, and the JavaScript-Cookie handling with autoclear. &lt;br&gt;For more information use the Cookie Tour. Press Next.</source>
 			</trans-unit>
 			<trans-unit id="tour.service.s9.title" resname="tour.service.s9.title">
-				<source>Iframe manager</source>
+				<source>iFrame Manager</source>
 			</trans-unit>
 			<trans-unit id="tour.service.s9.content" resname="tour.service.s9.content" xml:space="preserve">
-				<source>Here you can set the Iframe manager Texts. For more information have a look at the Documentation. &lt;br&gt; Press Next.</source>
+				<source>Here you can set the iFrame manager Texts. For more information have a look at the Documentation. &lt;br&gt; Press Next.</source>
 			</trans-unit>
 			<trans-unit id="tour.service.s10.title" resname="tour.service.s10.title">
 				<source>Embed URL</source>
 			</trans-unit>
 			<trans-unit id="tour.service.s10.content" resname="tour.service.s10.content" xml:space="preserve">
-				<source>Here you can add a JavaScript function, that is used to embed the Iframe on consent accept. &lt;br&gt; Default iframes are managed by the iFrame manager itself, you only need this for special embeds. &lt;br&gt; Press Next.</source>
+				<source>Here you can add a JavaScript function, that is used to embed the iframe on consent accept. &lt;br&gt; Default iframes are managed by the iFrame manager itself, you only need this for special embeds. &lt;br&gt; Press Next.</source>
 			</trans-unit>
 			<trans-unit id="tour.service.s11.title" resname="tour.service.s11.title">
 				<source>Thumbnail manager</source>
 			</trans-unit>
 			<trans-unit id="tour.service.s11.content" resname="tour.service.s11.content" xml:space="preserve">
-				<source>Here you can place a Javascript Function to fetch a Thumbnail for the Iframe, in a GDPR compliant way! &lt;a href='https://docs.typo3.org/p/codingfreaks/cf-cookiemanager/main/en-us/Configuration/CookieServices/Index.html#advanced-iframe-configuration'&gt;Documentation&lt;/a&gt; &lt;br&gt; Press Next.</source>
+				<source>Here you can place a JavaScript Function to fetch a Thumbnail for the iframe, in a GDPR compliant way! &lt;a href='https://docs.typo3.org/p/codingfreaks/cf-cookiemanager/main/en-us/Configuration/CookieServices/Index.html#advanced-iframe-configuration'&gt;Documentation&lt;/a&gt; &lt;br&gt; Press Next.</source>
 			</trans-unit>
 			<trans-unit id="tour.service.s12.title" resname="tour.service.s12.title">
 				<source>iFrame Notice</source>
@@ -331,7 +331,7 @@
 				<source>Script manager</source>
 			</trans-unit>
 			<trans-unit id="tour.service.s13.content" resname="tour.service.s13.content" xml:space="preserve">
-				<source>Execute Javascript on consent actions, for more information have a look at the Documentation. &lt;br&gt; Click on the Tab.</source>
+				<source>Execute JavaScript on consent actions, for more information have a look at the Documentation. &lt;br&gt; Click on the Tab.</source>
 			</trans-unit>
 			<trans-unit id="tour.service.s14.title" resname="tour.service.s14.title">
 				<source>Variable Provider</source>

--- a/Resources/Private/Language/locallang_js.xlf
+++ b/Resources/Private/Language/locallang_js.xlf
@@ -91,7 +91,7 @@
 				<source>new</source>
 			</trans-unit>
 			<trans-unit id="js.updateCheck.legendNewDesc" resname="js.updateCheck.legendNewDesc">
-				<source>New Datasets on API, not found in your Typo3 setup</source>
+				<source>New Datasets on API, not found in your TYPO3 setup</source>
 			</trans-unit>
 			<trans-unit id="js.updateCheck.legendUpdated" resname="js.updateCheck.legendUpdated">
 				<source>updated</source>
@@ -221,7 +221,7 @@
 				<source>Customize</source>
 			</trans-unit>
 			<trans-unit id="tour.frontend.s16.content" resname="tour.frontend.s16.content" xml:space="preserve">
-				<source>The Configuration of this cookiemanager is dumped into a .js file in the Typo3 Temp folder. &lt;br&gt; If you want to execute the Configuration inline, enable this option. &lt;br&gt; This is useful if you want to use the cookiemanager in a Single Page Application.</source>
+				<source>The Configuration of this cookiemanager is dumped into a .js file in the TYPO3 Temp folder. &lt;br&gt; If you want to execute the Configuration inline, enable this option. &lt;br&gt; This is useful if you want to use the cookiemanager in a Single Page Application.</source>
 			</trans-unit>
 			<trans-unit id="tour.frontend.s17.title" resname="tour.frontend.s17.title">
 				<source>Global Settings</source>
@@ -245,7 +245,7 @@
 				<source>Identifier</source>
 			</trans-unit>
 			<trans-unit id="tour.frontend.s20.content" resname="tour.frontend.s20.content" xml:space="preserve">
-				<source>The Identifier is used to identify the Language-Mapping between your Typo3 and the Coding-Freaks cookie API &lt;br&gt; &lt;strong&gt;Do not change, if you don't know what you are doing.&lt;/strong&gt;</source>
+				<source>The Identifier is used to identify the Language-Mapping between your TYPO3 and the CodingFreaks cookie API &lt;br&gt; &lt;strong&gt;Do not change, if you don't know what you are doing.&lt;/strong&gt;</source>
 			</trans-unit>
 			<trans-unit id="tour.frontend.s21.title" resname="tour.frontend.s21.title">
 				<source>Save and close</source>

--- a/Resources/Private/Language/locallang_js.xlf
+++ b/Resources/Private/Language/locallang_js.xlf
@@ -143,7 +143,7 @@
 				<source>Languages</source>
 			</trans-unit>
 			<trans-unit id="tour.frontend.s3.content" resname="tour.frontend.s3.content" xml:space="preserve">
-				<source>In the Frontend selection you can filter trough Frontend-languages to edit.&lt;br&gt;  Press next to continue.</source>
+				<source>In the Frontend selection you can filter through Frontend-languages to edit.&lt;br&gt;  Press next to continue.</source>
 			</trans-unit>
 			<trans-unit id="tour.frontend.s4.title" resname="tour.frontend.s4.title">
 				<source>Edit a Frontend Setting</source>
@@ -197,7 +197,7 @@
 				<source>Layout</source>
 			</trans-unit>
 			<trans-unit id="tour.frontend.s12.content" resname="tour.frontend.s12.content">
-				<source>Change  the text above the Buttons</source>
+				<source>Change the text above the Buttons</source>
 			</trans-unit>
 			<trans-unit id="tour.frontend.s13.title" resname="tour.frontend.s13.title">
 				<source>Layout</source>
@@ -221,7 +221,7 @@
 				<source>Customize</source>
 			</trans-unit>
 			<trans-unit id="tour.frontend.s16.content" resname="tour.frontend.s16.content" xml:space="preserve">
-				<source>The Configuration of this cookiemanager is dumpes into a .js file in the Typo3 Temp folder. &lt;br&gt; If you want to execute the Configuration inline, enable this option. &lt;br&gt; This is useful if you want to use the cookiemanager in a Single Page Application.</source>
+				<source>The Configuration of this cookiemanager is dumped into a .js file in the Typo3 Temp folder. &lt;br&gt; If you want to execute the Configuration inline, enable this option. &lt;br&gt; This is useful if you want to use the cookiemanager in a Single Page Application.</source>
 			</trans-unit>
 			<trans-unit id="tour.frontend.s17.title" resname="tour.frontend.s17.title">
 				<source>Global Settings</source>
@@ -245,7 +245,7 @@
 				<source>Identifier</source>
 			</trans-unit>
 			<trans-unit id="tour.frontend.s20.content" resname="tour.frontend.s20.content" xml:space="preserve">
-				<source>The Identifier is used to identify the Language-Mapping between your Typo3 and the Coding-Freaks cookie API &lt;br&gt; &lt;strong&gt;Do not change, if you dont know what you are doing.&lt;/strong&gt;</source>
+				<source>The Identifier is used to identify the Language-Mapping between your Typo3 and the Coding-Freaks cookie API &lt;br&gt; &lt;strong&gt;Do not change, if you don't know what you are doing.&lt;/strong&gt;</source>
 			</trans-unit>
 			<trans-unit id="tour.frontend.s21.title" resname="tour.frontend.s21.title">
 				<source>Save and close</source>
@@ -259,13 +259,13 @@
 				<source>Cookie Services Tour</source>
 			</trans-unit>
 			<trans-unit id="tour.service.s1.content" resname="tour.service.s1.content">
-				<source>In this example we crate a new service from scratch.</source>
+				<source>In this example we create a new service from scratch.</source>
 			</trans-unit>
 			<trans-unit id="tour.service.s2.title" resname="tour.service.s2.title">
 				<source>Create new Service</source>
 			</trans-unit>
 			<trans-unit id="tour.service.s2.content" resname="tour.service.s2.content" xml:space="preserve">
-				<source>In the background a empty new service was created. &lt;br&gt;&lt;br&gt; We need to set some basic information. Such as the &lt;strong&gt;name&lt;/strong&gt;, the &lt;strong&gt;identifier&lt;/strong&gt; and the &lt;strong&gt;description&lt;/strong&gt;. &lt;br&gt;In this example we use &lt;strong&gt;OpenStreetmap&lt;/strong&gt; from the documentation example: &lt;a target="_blank" href="https://docs.typo3.org/p/codingfreaks/cf-cookiemanager/main/en-us/Developer/CustomServices/Index.html#leaflet-openstreetmap"&gt;CLICK HERE -&gt;&lt;/a&gt;. &lt;br&gt; Type a name like "My OpenStreetmap Service" and press next.</source>
+				<source>In the background an empty new service was created. &lt;br&gt;&lt;br&gt; We need to set some basic information. Such as the &lt;strong&gt;name&lt;/strong&gt;, the &lt;strong&gt;identifier&lt;/strong&gt; and the &lt;strong&gt;description&lt;/strong&gt;. &lt;br&gt;In this example we use &lt;strong&gt;OpenStreetmap&lt;/strong&gt; from the documentation example: &lt;a target="_blank" href="https://docs.typo3.org/p/codingfreaks/cf-cookiemanager/main/en-us/Developer/CustomServices/Index.html#leaflet-openstreetmap"&gt;CLICK HERE -&gt;&lt;/a&gt;. &lt;br&gt; Type a name like "My OpenStreetmap Service" and press next.</source>
 			</trans-unit>
 			<trans-unit id="tour.service.s3.title" resname="tour.service.s3.title">
 				<source>Service identifier</source>
@@ -313,13 +313,13 @@
 				<source>Embed URL</source>
 			</trans-unit>
 			<trans-unit id="tour.service.s10.content" resname="tour.service.s10.content" xml:space="preserve">
-				<source>Here you can add a JavaScript function, that is used to embed the Iframe on consent accept. &lt;br&gt; Default iframes are managed by the iFrame manager self, you only need this for special embeds. &lt;br&gt; Press Next.</source>
+				<source>Here you can add a JavaScript function, that is used to embed the Iframe on consent accept. &lt;br&gt; Default iframes are managed by the iFrame manager itself, you only need this for special embeds. &lt;br&gt; Press Next.</source>
 			</trans-unit>
 			<trans-unit id="tour.service.s11.title" resname="tour.service.s11.title">
 				<source>Thumbnail manager</source>
 			</trans-unit>
 			<trans-unit id="tour.service.s11.content" resname="tour.service.s11.content" xml:space="preserve">
-				<source>Here you can place a Javascript Function to fetch a Thumbnail for the Iframe, in a GDPR conform way! &lt;a href='https://docs.typo3.org/p/codingfreaks/cf-cookiemanager/main/en-us/Configuration/CookieServices/Index.html#advanced-iframe-configuration'&gt;Documentation&lt;/a&gt; &lt;br&gt; Press Next.</source>
+				<source>Here you can place a Javascript Function to fetch a Thumbnail for the Iframe, in a GDPR compliant way! &lt;a href='https://docs.typo3.org/p/codingfreaks/cf-cookiemanager/main/en-us/Configuration/CookieServices/Index.html#advanced-iframe-configuration'&gt;Documentation&lt;/a&gt; &lt;br&gt; Press Next.</source>
 			</trans-unit>
 			<trans-unit id="tour.service.s12.title" resname="tour.service.s12.title">
 				<source>iFrame Notice</source>

--- a/Resources/Private/Language/locallang_module.xlf
+++ b/Resources/Private/Language/locallang_module.xlf
@@ -43,12 +43,12 @@
 				<source>Welcome to CodingFreaks Cookie Manager</source>
 			</trans-unit>
 			<trans-unit id="index.welcome.noConfig" resname="index.welcome.noConfig" xml:space="preserve">
-				<source>No Site or typoscript configuration found for this Root-Page (ID:%s). &lt;br&gt; Please check your Typo3 configuration or import the SiteSet and include the Typoscript for this Root-Page.</source>
+				<source>No Site or typoscript configuration found for this Root-Page (ID:%s). &lt;br&gt; Please check your TYPO3 configuration or import the SiteSet and include the Typoscript for this Root-Page.</source>
 			</trans-unit>
 
 			<!-- ==================== Onboarding: welcome screen ==================== -->
 			<trans-unit id="index.onboarding.welcome.heading" resname="index.onboarding.welcome.heading">
-				<source>Welcome to Coding-Freaks Cookie Manager 🚀</source>
+				<source>Welcome to CodingFreaks Cookie Manager 🚀</source>
 			</trans-unit>
 			<trans-unit id="index.onboarding.welcome.intro" resname="index.onboarding.welcome.intro">
 				<source>Let's get started and set up your cookie management in just a few steps!</source>
@@ -82,7 +82,7 @@
 
 			<!-- ==================== Onboarding: step 1 (feedback) ==================== -->
 			<trans-unit id="index.onboarding.step1.heading" resname="index.onboarding.step1.heading">
-				<source>Thanks for using Coding-Freaks Cookie-Manager</source>
+				<source>Thanks for using CodingFreaks Cookie-Manager</source>
 			</trans-unit>
 			<trans-unit id="index.onboarding.step1.intro" resname="index.onboarding.step1.intro" xml:space="preserve">
 				<source>We continuously strive to make our cookie manager better.&lt;br&gt;To do this, we kindly ask for your permission to collect usage data during installation and while using the extension.&lt;br&gt;</source>
@@ -120,7 +120,7 @@
 				<source>You can skip this step and add full API-Integration later.</source>
 			</trans-unit>
 			<trans-unit id="index.onboarding.step2.intro" resname="index.onboarding.step2.intro" xml:space="preserve">
-				<source>To optimally use the Extension and our API services, these features are exclusively available to API users (Free).&lt;br&gt;Sign up now for a free Open-Beta account on &lt;a target="_blank" href="https://coding-freaks.com/register"&gt;Coding-Freaks&lt;/a&gt; to get the most out of the Cookiemanager Extension!</source>
+				<source>To optimally use the Extension and our API services, these features are exclusively available to API users (Free).&lt;br&gt;Sign up now for a free Open-Beta account on &lt;a target="_blank" href="https://coding-freaks.com/register"&gt;CodingFreaks&lt;/a&gt; to get the most out of the Cookiemanager Extension!</source>
 			</trans-unit>
 			<trans-unit id="index.onboarding.feature.header.feature" resname="index.onboarding.feature.header.feature">
 				<source>Feature</source>
@@ -234,7 +234,7 @@
 				<source>powered by</source>
 			</trans-unit>
 			<trans-unit id="index.footer.questions" resname="index.footer.questions" xml:space="preserve">
-				<source>&lt;strong&gt;Questions?&lt;/strong&gt; Join the Typo3 Slack Channel #ext-cfcookiemanager</source>
+				<source>&lt;strong&gt;Questions?&lt;/strong&gt; Join the TYPO3 Slack Channel #ext-cfcookiemanager</source>
 			</trans-unit>
 			<trans-unit id="index.footer.documentation" resname="index.footer.documentation">
 				<source>CookieManager Documentation</source>
@@ -254,7 +254,7 @@
 				<source>Here you can configure your categories and the assigned services per language.</source>
 			</trans-unit>
 			<trans-unit id="home.updatePending" resname="home.updatePending" xml:space="preserve">
-				<source>You have pending Update Wizards for this extension. &lt;br&gt; Please complete the wizards in the Typo3-Upgrade center before using this Module.</source>
+				<source>You have pending Update Wizards for this extension. &lt;br&gt; Please complete the wizards in the TYPO3-Upgrade center before using this Module.</source>
 			</trans-unit>
 			<trans-unit id="home.servicesAssigned" resname="home.servicesAssigned">
 				<source>Services assigned:</source>
@@ -558,7 +558,7 @@
 				<source>Extension Administration</source>
 			</trans-unit>
 			<trans-unit id="admin.subtitle" resname="admin.subtitle">
-				<source>Deep dive into Coding-Freaks CookieManager Datasets</source>
+				<source>Deep dive into CodingFreaks CookieManager Datasets</source>
 			</trans-unit>
 			<trans-unit id="admin.loadingUpdateIndex" resname="admin.loadingUpdateIndex">
 				<source>Loading update index from remote API...</source>
@@ -588,7 +588,7 @@
 				<source>Data Administration</source>
 			</trans-unit>
 			<trans-unit id="admin.dataAdmin.text" resname="admin.dataAdmin.text">
-				<source>Complete Integration for the Coding-Freaks API.</source>
+				<source>Complete Integration for the CodingFreaks API.</source>
 			</trans-unit>
 
 			<!-- ==================== Flash messages (PHP) ==================== -->

--- a/Resources/Private/Language/locallang_module.xlf
+++ b/Resources/Private/Language/locallang_module.xlf
@@ -60,7 +60,7 @@
 				<source>Start Configuration</source>
 			</trans-unit>
 			<trans-unit id="index.onboarding.recommended" resname="index.onboarding.recommended">
-				<source>(Recomended)</source>
+				<source>(Recommended)</source>
 			</trans-unit>
 			<trans-unit id="index.onboarding.offlineConfiguration" resname="index.onboarding.offlineConfiguration">
 				<source>Offline Configuration</source>
@@ -197,7 +197,7 @@
 				<source>Discover how to scan your website for cookies and configure them easily.</source>
 			</trans-unit>
 			<trans-unit id="index.onboarding.tutorials.learnMore" resname="index.onboarding.tutorials.learnMore">
-				<source>lean more</source>
+				<source>learn more</source>
 			</trans-unit>
 			<trans-unit id="index.onboarding.tutorials.workflow.title" resname="index.onboarding.tutorials.workflow.title">
 				<source>Implement a Cookie Workflow</source>
@@ -275,10 +275,10 @@
 				<source>Tutorial Section</source>
 			</trans-unit>
 			<trans-unit id="home.tutorial.intro" resname="home.tutorial.intro" xml:space="preserve">
-				<source>Let guide you through the configuration with a Live Tutorial.&lt;br&gt; Click on a "start" button below to start a Guided Tour.</source>
+				<source>Let us guide you through the configuration with a Live Tutorial.&lt;br&gt; Click on a "start" button below to start a Guided Tour.</source>
 			</trans-unit>
 			<trans-unit id="home.tutorial.frontend.desc" resname="home.tutorial.frontend.desc">
-				<source>Start a Tour thought the Frontend Settings.</source>
+				<source>Start a Tour through the Frontend Settings.</source>
 			</trans-unit>
 			<trans-unit id="home.tutorial.frontend.button" resname="home.tutorial.frontend.button">
 				<source>Start Frontend Tour</source>

--- a/Resources/Private/Language/locallang_module.xlf
+++ b/Resources/Private/Language/locallang_module.xlf
@@ -314,16 +314,16 @@
 				<source>Cookiebanner hidden from Bots:</source>
 			</trans-unit>
 			<trans-unit id="home.setting.autorunConsent" resname="home.setting.autorunConsent">
-				<source>Run consent modal on page load:</source>
+				<source>Run Consent Modal on page load:</source>
 			</trans-unit>
 			<trans-unit id="home.setting.forceConsent" resname="home.setting.forceConsent">
-				<source>Block page navigation until user consent modal action:</source>
+				<source>Block page navigation until user Consent Modal action:</source>
 			</trans-unit>
 			<trans-unit id="home.setting.revisionVersion" resname="home.setting.revisionVersion">
 				<source>Frontend-Consent revision version:</source>
 			</trans-unit>
 			<trans-unit id="home.setting.thumbnailApi" resname="home.setting.thumbnailApi">
-				<source>Thumbnail API for Iframemanager:</source>
+				<source>Thumbnail API for iFrame Manager:</source>
 			</trans-unit>
 			<trans-unit id="home.extensionSettings.button" resname="home.extensionSettings.button">
 				<source>Extension Settings -&gt;</source>
@@ -343,7 +343,7 @@
 				<source>Scan Target</source>
 			</trans-unit>
 			<trans-unit id="autoconfig.scanTarget.help" resname="autoconfig.scanTarget.help">
-				<source>URL or Sitemap.xml path (ex. https://example.com or https://example.com/sitemap.xml)</source>
+				<source>URL or Sitemap.xml path (e.g. https://example.com or https://example.com/sitemap.xml)</source>
 			</trans-unit>
 			<trans-unit id="autoconfig.maxPages.label" resname="autoconfig.maxPages.label">
 				<source>Max pages</source>
@@ -478,16 +478,16 @@
 				<source>Report</source>
 			</trans-unit>
 			<trans-unit id="autoconfig.help.whatHeading" resname="autoconfig.help.whatHeading">
-				<source>What is Auto-configuration?</source>
+				<source>What is Autoconfiguration?</source>
 			</trans-unit>
 			<trans-unit id="autoconfig.help.whatText" resname="autoconfig.help.whatText">
-				<source>Auto Configuration is responsible for identifying Services used on your website. Use it as a starting point for your analysis.</source>
+				<source>Autoconfiguration is responsible for identifying Services used on your website. Use it as a starting point for your analysis.</source>
 			</trans-unit>
 			<trans-unit id="autoconfig.help.howHeading" resname="autoconfig.help.howHeading">
 				<source>How to use the Autoconfiguration?</source>
 			</trans-unit>
 			<trans-unit id="autoconfig.help.howText" resname="autoconfig.help.howText" xml:space="preserve">
-				<source>By clicking on the Scan button, an external web scanner will scan 10 pages of your website and detect any embedded scripts, iframes, and cookies.&lt;br&gt;These can be imported using the Import button after a successful scan.&lt;br&gt;Existing services will be ignored and only new services will be added if they are detected.&lt;br&gt;&lt;br&gt;You can use a custom sitemap.xml to target the 10 Pages. (ex. %s/sitemap.xml)</source>
+				<source>By clicking on the Scan button, an external web scanner will scan 10 pages of your website and detect any embedded scripts, iframes, and cookies.&lt;br&gt;These can be imported using the Import button after a successful scan.&lt;br&gt;Existing services will be ignored and only new services will be added if they are detected.&lt;br&gt;&lt;br&gt;You can use a custom sitemap.xml to target the 10 Pages. (e.g. %s/sitemap.xml)</source>
 			</trans-unit>
 			<trans-unit id="autoconfig.docsButton" resname="autoconfig.docsButton">
 				<source>Autoconfiguration Docs</source>
@@ -538,7 +538,7 @@
 				<source>Service Configuration</source>
 			</trans-unit>
 			<trans-unit id="services.subtitle" resname="services.subtitle">
-				<source>Static Scripts and Text management, Iframe embeds and more..</source>
+				<source>Static Scripts and Text management, iframe embeds and more..</source>
 			</trans-unit>
 			<trans-unit id="services.createNew" resname="services.createNew">
 				<source>Create new Service</source>
@@ -547,7 +547,7 @@
 				<source>Service Configuration</source>
 			</trans-unit>
 			<trans-unit id="services.help.text" resname="services.help.text">
-				<source>Cookie services responsible for the Iframe and Script management of the website.</source>
+				<source>Cookie services responsible for the iframe and Script management of the website.</source>
 			</trans-unit>
 			<trans-unit id="services.docsButton" resname="services.docsButton">
 				<source>Cookie Services Docs -&gt;</source>
@@ -620,7 +620,7 @@
 				<source>Select override for deleting old references, to import new as selected. Select ignore, to skip the record.</source>
 			</trans-unit>
 			<trans-unit id="flash.overview.title" resname="flash.overview.title">
-				<source>AutoConfiguration overview</source>
+				<source>Autoconfiguration overview</source>
 			</trans-unit>
 			<trans-unit id="flash.scanStarted.message" resname="flash.scanStarted.message">
 				<source>New Scan started, this can take some minutes..</source>
@@ -637,7 +637,7 @@
 
 			<!-- ==================== AJAX errors (PHP) ==================== -->
 			<trans-unit id="error.request" resname="error.request">
-				<source>Error in Request, please make a Issue on Github</source>
+				<source>Error in Request, please make a Issue on GitHub</source>
 			</trans-unit>
 			<trans-unit id="error.localDataset" resname="error.localDataset">
 				<source>Error in Local Dataset Installation, maybe wrong file format or missing files</source>


### PR DESCRIPTION
Correct spelling and grammar mistakes in the English source labels of the backend module, TCA and backend JavaScript (locallang_module.xlf, locallang_db.xlf, locallang_js.xlf). Also align wording/casing (GDPR compliant, DSGVO). No key changes, translation-only.